### PR TITLE
feat: 열린 문의 웨이포인트를 봇들이 공유하고 각각의 봇이 방문한 웨이포인트,를 따로 기억함. 우선순위를 추가하여 로직 …

### DIFF
--- a/Assets/Scripts/Bot/DoorNavObstacle.cs
+++ b/Assets/Scripts/Bot/DoorNavObstacle.cs
@@ -5,7 +5,6 @@ using Unity.Netcode;
 // 문의 NavMeshObstacle을 관리함, 문이 열릴 때 봇들이 자동으로 경로 변경
 public class DoorNavObstacle : MonoBehaviour
 {
-
     [Header("References")]
     [SerializeField] private NavMeshObstacle doorNavObstacle;
 
@@ -45,8 +44,8 @@ public class DoorNavObstacle : MonoBehaviour
 
         if (nearWaypoint == null) return; // 없으면 패스
 
-        // 가장 가까운 웨이포인트로 모든 봇 강제 전환
-        BotController.ForceAllBotsToWaypoint(nearWaypoint);
+        // 열린 문의 웨이포인트를 우선 방문 목록에 추가
+        BotController.RegisterOpenedDoorWaypoint(nearWaypoint);
     }
 
     // 문 위치 기준 가장 가까운 Waypoint 태그 오브젝트 찾기


### PR DESCRIPTION
…수정 (#323)

- 열린 문 웨이포인트를 기억하기 위한 전역 리스트 사용
- 각 봇이 방문한 웨이포인트를 기억하기 위한 해쉬셋 사용
- 강제 방문 모드 이후 문 우선 순위에 따라서 방문
- 도달시 visitedDoorWaypoints에 기록하여 재방문 방지