### PR TITLE
fix: 버프 아이템이 먹자 말자 바로 리스폰되는 현상 수정

### DIFF
--- a/Assets/Scripts/Item/BuffItem.cs
+++ b/Assets/Scripts/Item/BuffItem.cs
@@ -34,9 +34,35 @@ public abstract class BuffItem : InteractiveItem
         // 플레이어의 버프 픽업 이펙트 재생
         Holder.PlayBuffPickupEffect();
 
+        // 스포너에게 아이템이 소비되었음을 알림
+        NotifySpawnerItemConsumed();
+
         base.ActivateItem();
     }
 
     // 버프를 받을 플레이어
     protected abstract void ApplyBuffToPlayer(PlayerController player);
+
+    // 가장 가까운 ItemSpawner에게 알림
+    private void NotifySpawnerItemConsumed()
+    {
+        ItemSpawner[] spawners = FindObjectsByType<ItemSpawner>(FindObjectsSortMode.None);
+        ItemSpawner closestSpawner = null;
+        float closestDistance = float.MaxValue;
+
+        foreach (var spawner in spawners)
+        {
+            float distance = Vector3.Distance(transform.position, spawner.transform.position);
+            if (distance < closestDistance)
+            {
+                closestDistance = distance;
+                closestSpawner = spawner;
+            }
+        }
+
+        if (closestSpawner != null)
+        {
+            closestSpawner.OnItemConsumed();
+        }
+    }
 }

--- a/Assets/Scripts/Item/ItemSpawner.cs
+++ b/Assets/Scripts/Item/ItemSpawner.cs
@@ -112,4 +112,13 @@ public class ItemSpawner : NetworkBehaviour
             }
         }
     }
+
+    // 아이템이 사용되었을 때 외부에서 호출하는 메서드
+    public void OnItemConsumed()
+    {
+        if (!IsServer) return;
+
+        currentItem = null;
+        nextSpawnTime = Time.time + spawnInterval;
+    }
 }


### PR DESCRIPTION
- 잡는 순간 즉시 ActivateItem() → Despawn() 호출 currentItem.IsSpawned가 거의 즉시 false가 됨 하지만 nextSpawnTime은 처음 스폰했을 때부터 계산되어 있음
-  아이템이 먹혔을 때 스포너에게 알리는 방법으로 바꿈